### PR TITLE
Made to persist on PAPI reload

### DIFF
--- a/src/main/java/com/bergerkiller/bukkit/sl/PAPI/PlaceholderAPIHandlerWithExpansions.java
+++ b/src/main/java/com/bergerkiller/bukkit/sl/PAPI/PlaceholderAPIHandlerWithExpansions.java
@@ -259,6 +259,12 @@ public class PlaceholderAPIHandlerWithExpansions implements PlaceholderAPIHandle
             return Arrays.asList(Variables.getNames());
         }
 
+     
+        @Override
+        public boolean persist() {
+            return true; // This is required or else PlaceholderAPI will unregister the Expansion on reload
+        }
+        
         @Override
         public String onRequest(final OfflinePlayer player, String identifier) {
             Variable variable = Variables.getIfExists(identifier);


### PR DESCRIPTION
Fixes #15 by adding persist() to PlaceholderExpansion class, as noted in the PAPI Documentation.